### PR TITLE
add a page for the code of conduct and a link in the "About" page.

### DIFF
--- a/about.md
+++ b/about.md
@@ -29,6 +29,11 @@ On the other hand, large-scale *collaborative* and *Open Science* projects have 
 
 ***
 
+### Code of conduct
+Check our [code of conduct]({{site.baseurl}}/code_conduct/) for a full description of our pledge, standards, responsabilities, and scope.
+
+***
+
 ### Definitions and Roles
 **ManyBabies** activities are guided by the principles of:
 * *Transparency*: All decisions in a **MB** project, from design to publication, are as transparent as possible;
@@ -36,9 +41,6 @@ On the other hand, large-scale *collaborative* and *Open Science* projects have 
 * *Inclusivity and diversity*: **MB** explicitly encourages efforts to increase diversity. This includes active applications for funding to assist laboratories from under-represented communities to participate, outreach efforts, and planning workshops;
 * *Ethical research*: **MB** projects are committed to best practices and high ethical standards;
 * *Respect*: Everyone agrees to a general code of conduct which ensures respectful interactions.
-
-Check our [code of conduct](https://docs.google.com/document/d/1UYSevbWnBQwd_eaBe1oKkOBX-8sMsBfiPz2kwNp7Ttc/export?format=pdf).
-Note that this is a living document. Comments and questions are explicitly encouraged. [Here is a version of the document that allows (anonymous) comments](https://docs.google.com/document/d/1UYSevbWnBQwd_eaBe1oKkOBX-8sMsBfiPz2kwNp7Ttc/edit).
 
 ***
 

--- a/code_conduct.md
+++ b/code_conduct.md
@@ -1,0 +1,53 @@
+---
+layout: page
+title: Code of conduct
+---
+<!--
+Obs.
+- from google docs living document
+- last update: 07/07/2020 ("stampo add to the page")
+
+-->
+
+*last update: 07/07/2020*
+
+### Our Pledge
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, political perspective, status within the community, personal appearance, race, religion, or sexual identity and orientation.
+
+### Our Standards
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by contributors include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+### Our Responsibilities
+The governing board and project leads are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+The governing board and project leads have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, emails, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+### Scope
+This Code of Conduct applies both within project spaces (OSF, github, mailing lists) and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event (e.g. during a conference presentation or at a meetup). Representation of a project may be further defined and clarified by the governing board.
+
+### Enforcement
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the [ManyBabies governing board](mailto:manybabies-gb@mailman.stanford.edu) or any of its members. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances, ranging from discussion of these policies to expulsion from the group, including all mailing lists (either for a set time span or permanently). It is at the complainant’s discretion to pursue additional action through other legal or institutional mechanisms. The governing board is obligated to maintain confidentiality with regard to the reporter of an incident. In cases of complaints directly to project leads or governing board members, the reporter's identity will be known only to those directly contacted by the complainant, unless the complainant’s explicit permission is obtained.
+
+Governing board members or project leads who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the governing board or project's leadership.
+
+Further details of specific enforcement policies may be posted separately.
+
+### Attribution
+This Code of Conduct is adapted from the [Contributor Covenant, version 1.4](https://www.contributor-covenant.org/version/1/4/code-of-conduct.html) and from the [Psych-DS Code of Conduct](https://github.com/psych-ds/psych-DS/blob/master/CODE_OF_CONDUCT.md) (retrieved on 2018-11-23).
+
+### Contribute
+Note that this is a living document. Comments and questions are explicitly encouraged. [Here is a version of the document that allows (anonymous) comments](https://docs.google.com/document/d/1UYSevbWnBQwd_eaBe1oKkOBX-8sMsBfiPz2kwNp7Ttc/edit).


### PR DESCRIPTION
Added a page with the full description of the MB code of conduct and a link to it in the About page.
